### PR TITLE
Use custom domain name finder

### DIFF
--- a/certbot_dns_onecom/dns_onecom.py
+++ b/certbot_dns_onecom/dns_onecom.py
@@ -93,7 +93,7 @@ class _OneComClient(object):
         login_url = login_form['action']
 
         res = self.session.post(login_url, data=data)
-        if res.status_code != 200:
+        if res.status_code != 200 or "Invalid username or password." in res.text:
             raise Exception(f'Login failed for {self.username}: {res.text}')
 
     def get_root_domain(self, start_domain):

--- a/certbot_dns_onecom/dns_onecom.py
+++ b/certbot_dns_onecom/dns_onecom.py
@@ -107,7 +107,7 @@ class _OneComClient(object):
                 return domain
             else:
                 # Domain does not exist, remove first subdomain and try again
-                domain = '.'.join(dom.split(".")[1:])
+                domain = '.'.join(domain.split(".")[1:])
 
         # We reached a top-level domain, raise an Exception
         raise Exception(f'Failed to find root domain for {start_domain}')

--- a/certbot_dns_onecom/dns_onecom.py
+++ b/certbot_dns_onecom/dns_onecom.py
@@ -96,10 +96,28 @@ class _OneComClient(object):
         if res.status_code != 200:
             raise Exception(f'Login failed for {self.username}: {res.text}')
 
+    def get_root_domain(self, start_domain):
+        domain = start_domain
+        # Loop over the subdomains
+        while domain.count('.') > 0:
+            # Get request, join list to string
+            res = self.session.get(f'https://www.one.com/admin/api/domains/{domain}/dns/custom_records')
+            if res.status_code == 200:
+                # Domain found
+                return domain
+            else:
+                # Domain does not exist, remove first subdomain and try again
+                domain = '.'.join(dom.split(".")[1:])
+
+        # We reached a top-level domain, raise an Exception
+        raise Exception(f'Failed to find root domain for {start_domain}')
+
+
     def add_txt_record(self, full_domain, validation_domain_name, validation):
         logger.debug(f'add_txt_record: {full_domain}, {validation_domain_name}, {validation}')
         self.login()
-        prefix = validation_domain_name.split('.')[0]
+        root_domain = self.get_root_domain(full_domain)
+        prefix = validation_domain_name.removesuffix(f'.{root_domain}')
         payload = {
             "type": "dns_custom_records",
             "attributes": {
@@ -110,20 +128,21 @@ class _OneComClient(object):
                 "content": validation
             }
         }
-        res = self.session.post(f'https://www.one.com/admin/api/domains/{full_domain}/dns/custom_records', json=payload)
+        res = self.session.post(f'https://www.one.com/admin/api/domains/{root_domain}/dns/custom_records', json=payload)
         if res.status_code != 200:
             raise Exception(f'Failed to add TXT record for {full_domain}: {res.text}')
 
     def del_txt_record(self, full_domain, validation_domain_name, validation):
         logger.debug(f'del_txt_record: {full_domain}, {validation_domain_name}, {validation}')
         self.login()
-        prefix = validation_domain_name.split('.')[0]
-        custom_records = self.session.get(f'https://www.one.com/admin/api/domains/{full_domain}/dns/custom_records').json()
+        root_domain = self.get_root_domain(full_domain)
+        prefix = validation_domain_name.removesuffix(f'.{root_domain}')
+        custom_records = self.session.get(f'https://www.one.com/admin/api/domains/{root_domain}/dns/custom_records').json()
         validation_record_ids = [rec["id"] for rec in custom_records['result']['data']
                                  if rec["attributes"]["type"] == "TXT"
                                  and rec["attributes"]["prefix"] == prefix]
 
         for record_id in validation_record_ids:
-            res = self.session.delete(f'https://www.one.com/admin/api/domains/{full_domain}/dns/custom_records/{record_id}')
+            res = self.session.delete(f'https://www.one.com/admin/api/domains/{root_domain}/dns/custom_records/{record_id}')
             if res.status_code != 200:
                 logger.warn(f'Failed to remove TXT {validation_domain_name}: {res.text}')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.1.0'
+version = '0.1.1'
 
 install_requires = [
     'acme>=0.21.1',


### PR DESCRIPTION
Given you want to generate a certificate for the domain "a.b.example.com" and you own "example.com" the settings should be applied to the root domain.

This change introduces a search functionality, which will try the different subdomains (["a.b.example.com", "b.example.com", "example.com]) to figure out the correct root domain.

This information is required for both finding the correct site to apply the settings and when actually adding and deleting TXT records.